### PR TITLE
#3 - Set up styles

### DIFF
--- a/src/client/components/Question.tsx
+++ b/src/client/components/Question.tsx
@@ -98,6 +98,7 @@ const Question: React.FC<QuestionProps> = ({
                     name="answer"
                     id={answer}
                     value={chosenAnswer}
+                    style={{ marginLeft: 0 }}
                   ></input>
                   <label htmlFor={answer}> {answer}</label>
                 </div>

--- a/src/client/components/Question.tsx
+++ b/src/client/components/Question.tsx
@@ -60,31 +60,83 @@ const Question: React.FC<QuestionProps> = ({
   };
 
   return (
-    <>
-      <div>{currentQuestion!.question}</div>
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "flex-start",
+        fontFamily: "sans-serif",
+      }}
+    >
+      <div>
+        <h3
+          style={{
+            fontWeight: 100,
+            fontSize: "20px",
+          }}
+        >
+          {currentQuestion!.question}
+        </h3>
+      </div>
 
-      {currentQuestion!.type !== "text" ? (
-        <form>
-          {allAnswers.map((answer, i) => {
-            return (
-              <div key={i}>
-                <input
-                  onChange={(e) => setAnswer(e.target.value)}
-                  type="radio"
-                  name="answer"
-                  id={answer}
-                  value={chosenAnswer}
-                ></input>
-                <label htmlFor={answer}> {answer}</label>
-              </div>
-            );
-          })}
-        </form>
-      ) : (
-        <input type="text"></input>
-      )}
-      <button onClick={handleClick}>Next</button>
-    </>
+      <form>
+        {currentQuestion!.type !== "text" ? (
+          <div style={{ marginBottom: "28px" }}>
+            {allAnswers.map((answer, i) => {
+              return (
+                <div
+                  key={i}
+                  style={{
+                    fontSize: "16px",
+                    fontWeight: 100,
+                    marginBottom: "10px",
+                  }}
+                >
+                  <input
+                    onChange={(e) => setAnswer(e.target.value)}
+                    type="radio"
+                    name="answer"
+                    id={answer}
+                    value={chosenAnswer}
+                  ></input>
+                  <label htmlFor={answer}> {answer}</label>
+                </div>
+              );
+            })}
+          </div>
+        ) : (
+          <div style={{ marginBottom: "16px" }}>
+            <input
+              type="text"
+              style={{
+                width: "100%",
+                padding: "12px 20px",
+                margin: "8px 0",
+                display: "inline-block",
+                border: "1px solid #ccc",
+                borderRadius: "4px",
+                boxSizing: "border-box",
+                fontSize: "16px",
+              }}
+            ></input>
+          </div>
+        )}
+      </form>
+      <button
+        style={{
+          borderRadius: "none",
+          padding: "10px 20px",
+          backgroundColor: "#1e70dd",
+          border: "none",
+          color: "#fff",
+          fontSize: "16px",
+          fontWeight: "lighter",
+        }}
+        onClick={handleClick}
+      >
+        Next
+      </button>
+    </div>
   );
 };
 


### PR DESCRIPTION
### EOD
The list of what still needs to be done is shrinking, and I am hoping to have this sent in by EOD tomorrow.
- [x] Figure out how to replace those HTML entities in the question and answer strings. I thought I had it with some help from lodash, but I couldn't quite get it there before I had to call it a day
- [x] Implement the styles started in this PR into the Summary component

Current View: 
![image](https://user-images.githubusercontent.com/49996098/91923973-3ca6c280-ec97-11ea-8aaa-0b940392e067.png)

Mockup:
![image](https://user-images.githubusercontent.com/49996098/91923994-4e886580-ec97-11ea-9409-b13f49918140.png)

- [x] Disable `Next` Button until a selection is made
- [x] Disable a user's ability to double-submit
- [x] Error
```
./src/client/components/Question.tsx
[start:client]   Line 51:6:  React Hook useEffect has a missing dependency: 'currentQuestion'. Either include it or remove the dependency array  react-hooks/exhaustive-deps
```

- [x] Bug - When two questions of type `text` are shown back to back, the second retains the value entered into the first.
